### PR TITLE
Found and fixed a bug with incorrect HAM levels on player creation

### DIFF
--- a/MMOCoreORB/src/server/zone/managers/creature/CreatureManagerImplementation.cpp
+++ b/MMOCoreORB/src/server/zone/managers/creature/CreatureManagerImplementation.cpp
@@ -434,6 +434,9 @@ CreatureObject* CreatureManagerImplementation::spawnCreature(uint32 templateCRC,
 
 	placeCreature(creature, x, z, y, parentID);
 
+	// ensuring the combat level and max HAM is correct.
+	if( creature->isPlayerCreature() )
+		creature->getPlayerObject()->recalculateCombatLevel(creature);
 	return creature;
 }
 

--- a/MMOCoreORB/src/server/zone/managers/player/PlayerManagerImplementation.cpp
+++ b/MMOCoreORB/src/server/zone/managers/player/PlayerManagerImplementation.cpp
@@ -915,6 +915,9 @@ void PlayerManagerImplementation::sendPlayerToCloner(CreatureObject* player, uin
 	// Jedi experience loss.
 	if (ghost->getJediState() > 1)
 		awardExperience(player, "jedi_general", -200000, true);
+
+	//Recalculating the combat level due to the potential for skill loss and adds a periodic verification
+	ghost->recalculateCombatLevel(player);
 }
 
 void PlayerManagerImplementation::ejectPlayerFromBuilding(CreatureObject* player) {
@@ -2868,10 +2871,14 @@ SortedVector<ManagedReference<SceneObject*> > PlayerManagerImplementation::getIn
 
 
 int PlayerManagerImplementation::calculatePlayerLevel(CreatureObject* player) {
+	//TODO delete me
+	//deprecated by PlayerObjectImplementation::calculateCombatLevel
  return player->getLevel();
 }
 
 int PlayerManagerImplementation::calculatePlayerLevel(CreatureObject* player, String& xpType) {
+	//TODO delete me
+	//deprecated by PlayerObjectImplementation::calculateCombatLevel
  return calculatePlayerLevel(player);
 }
 

--- a/MMOCoreORB/src/server/zone/managers/player/creation/PlayerCreationManager.cpp
+++ b/MMOCoreORB/src/server/zone/managers/player/creation/PlayerCreationManager.cpp
@@ -648,6 +648,7 @@ bool PlayerCreationManager::createCharacter(MessageCallback* data) {
 
 	ghost->addSuiBox(box);
 	playerCreature->sendMessage(box->generateMessage());
+	ghost->recalculateCombatLevel(playerCreature);
 
 	return true;
 }

--- a/MMOCoreORB/src/server/zone/objects/player/PlayerObjectImplementation.cpp
+++ b/MMOCoreORB/src/server/zone/objects/player/PlayerObjectImplementation.cpp
@@ -842,6 +842,7 @@ void PlayerObjectImplementation::calculateCombatLevel(CreatureObject* creature)
 		else
 			additionalHam = 960 + 40 * (creatureLevel - 54);
 	}
+	//TODO ensure that this does not override buffs, and add flow control if it does.
 	creature->setBaseHAM(CreatureAttribute::HEALTH, 1000 + additionalHam, true);
 	creature->setMaxHAM(CreatureAttribute::HEALTH, creature->getBaseHAM(CreatureAttribute::HEALTH), true);
 


### PR DESCRIPTION
-Possible fix for incorrect combat levels and HAM values.
Added a combat level recalculation to:
PlayerManagerImplementation::sendPlayerToCloner() [last line of method]
PlayerCreationManager::createCharacter() [last line of method]
CreatureManagerImplementation::spawnCreature()

-Added a TODO note inside
PlayerObjectImplementation::calculateCombatLevel() to check for conflict
with buffs.